### PR TITLE
Update deploy script for pm2-based deployment workflow

### DIFF
--- a/sms-activate/deploy.sh
+++ b/sms-activate/deploy.sh
@@ -2,60 +2,19 @@
 set -euo pipefail
 
 # === Config ===
-APP_DIR="/home/client_28482_4/scripts/sms-activate"
-WEB_ROOT="/var/www/fakew.cyou/html"
-DOMAIN="fakew.cyou"
+APP_DIR="/home/client_28482_4/ZERKER/sms-activate"
 
-# === 1. Update repo / app ===
+echo "[+] Changing to application directory: $APP_DIR"
 cd "$APP_DIR"
-echo "[+] Building Docker container for app..."
-sudo docker-compose down -v || true
-sudo docker-compose up -d --build
 
-# === 2. Build frontend (if React/Vite exists) ===
-if [ -f package.json ] && grep -q "vite" package.json; then
-  echo "[+] Building frontend with Vite..."
-  npm install --legacy-peer-deps
-  npm run build
-  sudo mkdir -p "$WEB_ROOT"
-  sudo cp -r dist/* "$WEB_ROOT"/
-fi
+echo "[+] Pulling latest code from Git..."
+git pull --ff-only
 
-# === 3. Nginx config ===
-CONF_PATH="/etc/nginx/sites-available/$DOMAIN"
-sudo tee "$CONF_PATH" >/dev/null <<CONF
-server {
-    server_name $DOMAIN www.$DOMAIN;
+echo "[+] Installing production dependencies..."
+npm install --omit=dev
 
-    root $WEB_ROOT;
-    index index.html;
+echo "[+] Restarting pm2 process..."
+pm2 restart sms-activate
 
-    location / {
-        try_files \$uri /index.html;
-    }
-
-    location /api/ {
-        proxy_pass http://127.0.0.1:3000/;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host \$host;
-        proxy_cache_bypass \$http_upgrade;
-    }
-}
-CONF
-
-sudo ln -sf "$CONF_PATH" /etc/nginx/sites-enabled/
-sudo nginx -t && sudo systemctl reload nginx
-
-# === 4. Certbot SSL ===
-echo "[+] Ensuring SSL certs..."
-sudo certbot --nginx --non-interactive --agree-tos -m admin@$DOMAIN -d $DOMAIN -d www.$DOMAIN || true
-
-# === 5. Auto-restart docker ===
-echo "[+] Enabling Docker restart on reboot..."
-sudo systemctl enable docker || true
-
-# === Done ===
-echo "🚀 Deployment complete: https://$DOMAIN"
+echo "🚀 Deployment complete."
 


### PR DESCRIPTION
## Summary
- point deployment script at the sms-activate directory used in production
- replace docker/nginx provisioning steps with the requested git pull, npm install, and pm2 restart workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a637ab9c83298472726f8c118084