### PR TITLE
Add Express server entry point

### DIFF
--- a/sms-activate/server.js
+++ b/sms-activate/server.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+
+const auth = require('./auth'); // make sure auth.js exports a router
+const db = require('./db');     // if db.js sets up your persistence
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// auth routes
+app.use('/api/auth', auth);
+
+// placeholder purchases route
+app.get('/api/purchases', (req, res) => {
+  res.json({ ok: true, items: [] });
+});
+
+// serve static frontend
+app.use(express.static(path.join(__dirname, 'public')));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public/index.html'));
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => console.log(`✅ Server listening on :${PORT}`));


### PR DESCRIPTION
## Summary
- add a new Express server entry point that wires auth routes and static frontend hosting
- provide a placeholder purchases endpoint returning an empty payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e30cd72d8c83298ae9d1460f45c51b