### PR TITLE
Add Vite React frontend and static serving

### DIFF
--- a/sms-activate/frontend/index.html
+++ b/sms-activate/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SMS-Activate Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/sms-activate/frontend/package.json
+++ b/sms-activate/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/sms-activate/frontend/src/lib/api.js
+++ b/sms-activate/frontend/src/lib/api.js
@@ -1,0 +1,9 @@
+export async function api(path, opts = {}) {
+  const token = localStorage.getItem('token');
+  const headers = { ...(opts.headers||{}), 'Content-Type':'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(path, { ...opts, headers });
+  const data = await res.json().catch(()=> ({}));
+  if (!res.ok) throw new Error(data.error || res.statusText);
+  return data;
+}

--- a/sms-activate/frontend/src/main.jsx
+++ b/sms-activate/frontend/src/main.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Login from './pages/Login.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import AdminCredits from './pages/AdminCredits.jsx';
+
+const router = createBrowserRouter([
+  { path: '/', element: <Login/> },
+  { path: '/login', element: <Login/> },
+  { path: '/dashboard', element: <Dashboard/> },
+  { path: '/admin', element: <AdminCredits/> }
+]);
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <RouterProvider router={router}/>
+  </React.StrictMode>
+);

--- a/sms-activate/frontend/src/pages/AdminCredits.jsx
+++ b/sms-activate/frontend/src/pages/AdminCredits.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+export default function AdminCredits(){
+  const [users,setUsers]=useState([]);
+  const [email,setEmail]=useState('');
+  const [amount,setAmount]=useState('');
+  const [msg,setMsg]=useState('');
+
+  useEffect(()=>{ load(); },[]);
+  async function load(){ try{ const d=await api('/api/admin/users'); setUsers(d.users||[]); } catch{} }
+
+  async function addCredit(){
+    try{
+      const d=await api('/api/admin/add-credit',{method:'POST',body:JSON.stringify({email,amount})});
+      setMsg('Credit updated'); load();
+    }catch(e){ setMsg(e.message); }
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">Admin Credits</h1>
+      <div className="space-x-2 mb-4">
+        <input className="border p-2" placeholder="User email" value={email} onChange={e=>setEmail(e.target.value)} />
+        <input className="border p-2" placeholder="Amount" value={amount} onChange={e=>setAmount(e.target.value)} />
+        <button className="border p-2" onClick={addCredit}>Add Credit</button>
+      </div>
+      {msg && <div className="text-sm">{msg}</div>}
+      <table className="border">
+        <thead><tr><th>Email</th><th>Credits</th></tr></thead>
+        <tbody>
+          {users.map(u=><tr key={u.email}><td>{u.email}</td><td>{u.credits}</td></tr>)}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/sms-activate/frontend/src/pages/Dashboard.jsx
+++ b/sms-activate/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+export default function Dashboard(){
+  const [me,setMe]=useState(null);
+  useEffect(()=>{ (async()=>{
+    try{ setMe(await api('/api/me')); } catch { location.href='/login'; }
+  })(); },[]);
+  if(!me) return <div className="p-6">Loading…</div>;
+  return <div className="p-6">Welcome, {me.email}</div>;
+}

--- a/sms-activate/frontend/src/pages/Login.jsx
+++ b/sms-activate/frontend/src/pages/Login.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+export default function Login(){
+  const [email,setEmail]=useState('');
+  const [password,setPassword]=useState('');
+  const [err,setErr]=useState('');
+
+  const submit=async(e)=>{ e.preventDefault(); setErr('');
+    try{
+      const r=await fetch('/api/auth/login',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({email,password})
+      });
+      const data=await r.json();
+      if(!r.ok) throw new Error(data.error||'login failed');
+      localStorage.setItem('token', data.token);
+      location.href='/dashboard';
+    }catch(e){ setErr(e.message); }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <form onSubmit={submit} className="w-full max-w-sm space-y-4 border p-6 rounded-xl">
+        <h1 className="text-2xl font-bold">Login</h1>
+        <input className="w-full border p-2 rounded" placeholder="Email"
+          value={email} onChange={e=>setEmail(e.target.value)} />
+        <input className="w-full border p-2 rounded" type="password" placeholder="Password"
+          value={password} onChange={e=>setPassword(e.target.value)} />
+        {err && <div className="text-red-600 text-sm">{err}</div>}
+        <button className="w-full border p-2 rounded font-semibold" type="submit">Sign in</button>
+        <a className="block text-sm underline" href="/signup">Need an account? Sign up</a>
+      </form>
+    </div>
+  );
+}

--- a/sms-activate/frontend/vite.config.js
+++ b/sms-activate/frontend/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 },
+  build: { outDir: 'dist' }
+})

--- a/sms-activate/server.js
+++ b/sms-activate/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const path = require('path');
+const cors = require('cors');
+require('dotenv').config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// API routes
+app.use('/api/auth', require('./auth'));
+app.use('/api/oauth', require('./oauth'));
+app.use('/api/db', require('./db'));
+
+// Example purchases endpoint
+app.get('/api/purchases', (req,res)=> res.json({ok:true,items:[]}));
+
+// Serve frontend
+const distPath = path.join(__dirname,'frontend','dist');
+app.use(express.static(distPath));
+app.get('*',(req,res)=> res.sendFile(path.join(distPath,'index.html')));
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, ()=> console.log(`Server running on ${PORT}`));


### PR DESCRIPTION
## Summary
- add a Vite-powered React frontend with routing for login, dashboard, and admin credits views
- provide a shared API helper for authenticated requests
- serve the built frontend from the Express server entrypoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e314dabedc83298cccd1d0156c322a