### PR TITLE
Add React dashboard and minimal Express API scaffolding

### DIFF
--- a/.github/workflows/fixer.yml
+++ b/.github/workflows/fixer.yml
@@ -1,56 +1,29 @@
-git add .github/workflows/fixer.yml
-git commit -m "Fixer: force commit VERSION.txt to main"
-git push origin main
-name: Codex Fixer
+name: Fixer (QA – no push)
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches: [ main ]
-  workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * *"
 
 jobs:
-  fix:
+  qa:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repo
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: '18'
+          cache: 'npm'
 
       - name: Install deps
-        run: npm install
+        run: npm ci || npm install
 
-      - name: Lint code with ESLint
+      - name: Lint (best-effort)
         run: npx eslint . || true
 
-      - name: Format code with Prettier
-        run: npx prettier --write . || true
-
-      - name: Create version tag and update VERSION.txt
-        run: |
-          count=$(git tag -l "codex-v*" | wc -l)
-          new=$((count + 1))
-          tag="codex-v$new"
-
-          echo "$tag" > VERSION.txt
-
-          git config user.name "github-actions"
-          git config user.email "actions@github.com"
-
-          git checkout main
-          git add VERSION.txt
-          git commit -m "Update VERSION.txt to $tag" || echo "No changes"
-          git tag -f "$tag"
-
-      - name: Push changes back to GitHub
-        run: |
-          git push origin main --tags
-
+      - name: Format check (best-effort)
+        run: npx prettier --check . || true

--- a/sms-activate/.env.example
+++ b/sms-activate/.env.example
@@ -1,0 +1,7 @@
+# Server
+PORT=4000
+JWT_SECRET=change-me
+
+# Optional admin bootstrap
+ADMIN_EMAIL=admin@local
+ADMIN_PASSWORD=admin

--- a/sms-activate/frontend/index.html
+++ b/sms-activate/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SMS Activate</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/sms-activate/frontend/package.json
+++ b/sms-activate/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sms-activate-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.8"
+  }
+}

--- a/sms-activate/frontend/src/lib/api.js
+++ b/sms-activate/frontend/src/lib/api.js
@@ -1,0 +1,9 @@
+export async function api(path, opts = {}) {
+  const token = localStorage.getItem('token');
+  const headers = { ...(opts.headers || {}), 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(path, { ...opts, headers });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.ok === false) throw new Error(data.error || res.statusText);
+  return data;
+}

--- a/sms-activate/frontend/src/main.jsx
+++ b/sms-activate/frontend/src/main.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Login from './pages/Login.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import AdminCredits from './pages/AdminCredits.jsx';
+
+const router = createBrowserRouter([
+  { path: '/', element: <Login /> },
+  { path: '/login', element: <Login /> },
+  { path: '/dashboard', element: <Dashboard /> },
+  { path: '/admin', element: <AdminCredits /> }
+]);
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/sms-activate/frontend/src/pages/AdminCredits.jsx
+++ b/sms-activate/frontend/src/pages/AdminCredits.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+export default function AdminCredits() {
+  const [me, setMe] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [email, setEmail] = useState('');
+  const [amount, setAmount] = useState('');
+  const [msg, setMsg] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const info = await api('/api/me');
+        setMe(info);
+        if (info.role !== 'admin') return (location.href = '/');
+        load();
+      } catch {
+        location.href = '/';
+      }
+    })();
+  }, []);
+
+  async function load() {
+    try {
+      const d = await api('/api/admin/users');
+      setUsers(d.users || []);
+    } catch (e) {
+      setMsg(e.message);
+    }
+  }
+
+  async function addCredit() {
+    setMsg('');
+    try {
+      await api('/api/admin/add-credit', { method: 'POST', body: JSON.stringify({ email, amount }) });
+      setMsg('Credit updated');
+      setEmail(''); setAmount('');
+      load();
+    } catch (e) { setMsg(e.message); }
+  }
+
+  if (!me) return <div style={{ padding: 16 }}>Loading…</div>;
+
+  return (
+    <div style={{ padding: 16, display: 'grid', gap: 12 }}>
+      <div><a href="/dashboard">← Back</a></div>
+      <h2>Admin: Credits</h2>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <input placeholder="user email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input placeholder="amount (+/-)" value={amount} onChange={e => setAmount(e.target.value)} />
+        <button onClick={addCredit}>Apply</button>
+      </div>
+      {msg && <div>{msg}</div>}
+      <table border="1" cellPadding="6" style={{ borderCollapse: 'collapse', maxWidth: 640 }}>
+        <thead><tr><th>Email</th><th>Credits</th><th>Role</th></tr></thead>
+        <tbody>
+          {users.map(u => <tr key={u.email}><td>{u.email}</td><td>{u.credits}</td><td>{u.role || 'user'}</td></tr>)}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/sms-activate/frontend/src/pages/Dashboard.jsx
+++ b/sms-activate/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+export default function Dashboard() {
+  const [me, setMe] = useState(null);
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const info = await api('/api/me');
+        setMe(info);
+        const purch = await api('/api/purchases');
+        setItems(purch.items || []);
+      } catch {
+        location.href = '/';
+      }
+    })();
+  }, []);
+
+  if (!me) return <div style={{ padding: 16 }}>Loading…</div>;
+
+  return (
+    <div style={{ padding: 16, display: 'grid', gap: 12 }}>
+      <div>Welcome, <b>{me.email}</b> — credits: <b>{me.credits}</b>{me.role === 'admin' ? ' (admin)' : ''}</div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={() => { localStorage.removeItem('token'); fetch('/api/logout', { method: 'POST' }); location.href = '/'; }}>
+          Logout
+        </button>
+        {me.role === 'admin' && <a href="/admin">Go to Admin</a>}
+      </div>
+      <h3>Your purchases</h3>
+      <table border="1" cellPadding="6" style={{ borderCollapse: 'collapse', maxWidth: 640 }}>
+        <thead><tr><th>#</th><th>Service</th><th>Phone</th></tr></thead>
+        <tbody>
+          {items.length === 0 && <tr><td colSpan={3} style={{ opacity: 0.7 }}>No purchases yet</td></tr>}
+          {items.map((r, i) => <tr key={i}><td>{i + 1}</td><td>{r.service || '-'}</td><td>{r.phone || '-'}</td></tr>)}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/sms-activate/frontend/src/pages/Login.jsx
+++ b/sms-activate/frontend/src/pages/Login.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [err, setErr] = useState('');
+
+  async function submit(e) {
+    e.preventDefault();
+    setErr('');
+    try {
+      const r = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const d = await r.json();
+      if (!r.ok || d.ok === false) throw new Error(d.error || 'Login failed');
+      localStorage.setItem('token', d.token);
+      location.href = '/dashboard';
+    } catch (e) {
+      setErr(e.message);
+    }
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center', padding: 24 }}>
+      <form onSubmit={submit} style={{ width: 360, display: 'grid', gap: 12, border: '1px solid #ddd', borderRadius: 12, padding: 16 }}>
+        <h1 style={{ margin: 0 }}>Sign in</h1>
+        <input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} style={{ padding: 8 }} />
+        <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} style={{ padding: 8 }} />
+        {err && <div style={{ color: 'crimson', fontSize: 12 }}>{err}</div>}
+        <button type="submit" style={{ padding: 10, fontWeight: 600 }}>Login</button>
+        <small>Tip: admin is <code>ADMIN_EMAIL / ADMIN_PASSWORD</code> from server env.</small>
+      </form>
+    </div>
+  );
+}

--- a/sms-activate/frontend/vite.config.js
+++ b/sms-activate/frontend/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: true
+  },
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/sms-activate/index.js
+++ b/sms-activate/index.js
@@ -1,59 +1,137 @@
-<!doctype html>
-};
+// Express entry point for API + static frontend
+require('dotenv').config();
 
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+const fs = require('fs');
+const jwt = require('jsonwebtoken');
 
-// Telegram handler
-window.onTelegramAuth = async (user) => {
-const r = await fetch('/api/login-tg', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(user) });
-const d = await r.json();
-if (d.ok) { toast('Telegram login ✔'); fetchMe(); } else toast('Telegram login failed');
-};
+const app = express();
+const PORT = process.env.PORT || 4000;
+const JWT_SECRET = process.env.JWT_SECRET || process.env.SESSION_SECRET || 'dev-secret';
 
+// --- middleware
+app.use(cors());
+app.use(express.json());
 
-// Logout
-document.getElementById('logoutBtn').onclick = async () => {
-await fetch('/api/logout', { method: 'POST' });
-toast('Logged out');
-showLoggedOut();
-};
+// --- tiny JSON "db" on top of data/db.json (non-blocking, tiny project-friendly)
+const DATA_DIR = path.join(__dirname, 'data');
+const DB_FILE = path.join(DATA_DIR, 'db.json');
+if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+if (!fs.existsSync(DB_FILE)) fs.writeFileSync(DB_FILE, JSON.stringify({ users: {}, purchases: [] }, null, 2));
 
+function readDB() {
+  try { return JSON.parse(fs.readFileSync(DB_FILE, 'utf8')); }
+  catch { return { users: {}, purchases: [] }; }
+}
+function writeDB(db) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(db, null, 2));
+}
 
-// Buy number
-document.getElementById('buyBtn').onclick = async () => {
-const service = document.getElementById('svc').value.trim() || 'wa';
-const country = document.getElementById('ctry').value.trim() || '6';
-const r = await fetch('/api/buy-number', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ service, country }) });
-const d = await r.json();
-if (d.ok) { document.getElementById('buyMsg').textContent = `Number: ${d.number.phone} (req ${d.number.requestId || '-'})`; toast('Number requested'); loadPurchases(); }
-else { document.getElementById('buyMsg').textContent = `Error: ${d.error}`; toast('Failed'); }
-};
+// --- auth helpers
+function signToken(payload) {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: '7d' });
+}
+function authOptional(req, _res, next) {
+  const h = req.headers.authorization || '';
+  const token = h.startsWith('Bearer ') ? h.slice(7) : null;
+  if (token) {
+    try { req.user = jwt.verify(token, JWT_SECRET); } catch {}
+  }
+  next();
+}
+function requireAuth(req, res, next) {
+  authOptional(req, res, () => {
+    if (!req.user) return res.status(401).json({ ok: false, error: 'Unauthorized' });
+    next();
+  });
+}
+function requireAdmin(req, res, next) {
+  requireAuth(req, res, () => {
+    if (req.user.role !== 'admin') return res.status(403).json({ ok: false, error: 'Forbidden' });
+    next();
+  });
+}
 
+app.use(authOptional);
 
-async function loadPurchases() {
-const r = await fetch('/api/purchases');
-const d = await r.json();
-const tb = document.getElementById('purchTbody');
-tb.innerHTML = '';
-if (d.ok) {
-d.items.forEach((row, i) => {
-const tr = document.createElement('tr');
-tr.innerHTML = `<td class="py-1 opacity-70">${i+1}</td>
-<td>${row.service}</td>
-<td>${row.country}</td>
-<td class="font-mono">${row.phone || '-'}</td>
-<td>${row.status}</td>
-<td class="opacity-70">${row.created_at}</td>`;
-tb.appendChild(tr);
+// --- API: auth
+// Strategy:
+// - If ADMIN_EMAIL/ADMIN_PASSWORD provided, those creds become admin; everyone else is "user" (any password accepted unless you want to hard-enforce).
+// - Token is returned; client stores in localStorage and sends as Bearer token.
+app.post('/api/auth/login', (req, res) => {
+  const { email, password } = req.body || {};
+  if (!email) return res.status(400).json({ ok: false, error: 'Email required' });
+
+  const adminEmail = process.env.ADMIN_EMAIL || 'admin@local';
+  const adminPass  = process.env.ADMIN_PASSWORD || 'admin';
+
+  let role = 'user';
+  if (email === adminEmail) {
+    if (password !== adminPass) return res.status(401).json({ ok: false, error: 'Invalid admin credentials' });
+    role = 'admin';
+  }
+
+  // upsert user record
+  const db = readDB();
+  db.users[email] = db.users[email] || { email, credits: 0, role };
+  // keep admin role sticky
+  if (email === adminEmail) db.users[email].role = 'admin';
+  writeDB(db);
+
+  const token = signToken({ email, role: db.users[email].role });
+  res.json({ ok: true, token });
 });
+
+app.get('/api/me', requireAuth, (req, res) => {
+  const db = readDB();
+  const u = db.users[req.user.email] || { email: req.user.email, credits: 0, role: 'user' };
+  res.json({ ok: true, email: u.email, credits: u.credits, role: u.role });
+});
+
+app.post('/api/logout', (_req, res) => {
+  // client just drops its token; nothing server-side to do with stateless JWTs
+  res.json({ ok: true });
+});
+
+// --- API: admin
+app.get('/api/admin/users', requireAdmin, (_req, res) => {
+  const db = readDB();
+  res.json({ ok: true, users: Object.values(db.users) });
+});
+
+app.post('/api/admin/add-credit', requireAdmin, (req, res) => {
+  const { email, amount } = req.body || {};
+  const n = Number(amount);
+  if (!email || Number.isNaN(n)) return res.status(400).json({ ok: false, error: 'email and numeric amount required' });
+
+  const db = readDB();
+  db.users[email] = db.users[email] || { email, credits: 0, role: 'user' };
+  db.users[email].credits = Number(db.users[email].credits || 0) + n;
+  writeDB(db);
+  res.json({ ok: true, user: db.users[email] });
+});
+
+// --- API: purchases (placeholder)
+app.get('/api/purchases', (_req, res) => {
+  const db = readDB();
+  res.json({ ok: true, items: db.purchases || [] });
+});
+
+// --- Static frontend (Vite build)
+const distDir = path.join(__dirname, 'frontend', 'dist');
+if (fs.existsSync(distDir)) {
+  app.use(express.static(distDir));
+  app.get('*', (req, res) => {
+    // only fall back for non-api
+    if (req.path.startsWith('/api/')) return res.status(404).json({ ok: false, error: 'Not found' });
+    res.sendFile(path.join(distDir, 'index.html'));
+  });
+} else {
+  app.get('/', (_req, res) => res.send('Frontend not built yet. Run: cd frontend && npm ci && npm run build'));
 }
-}
 
-
-document.getElementById('refreshPurch').onclick = loadPurchases;
-
-
-// initial load
-fetchMe().then(loadPurchases);
-</script>
-</body>
-</html>
+app.listen(PORT, () => {
+  console.log(`sms-activate listening on http://127.0.0.1:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- replace the sms-activate entrypoint with an Express server that exposes auth/admin APIs and serves the built frontend assets
- add a Vite-powered React frontend with login, dashboard, and admin credits management screens that consume the new APIs
- document required environment variables and wire up a QA GitHub Actions workflow for lint/format checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3210230748329b3961d2c280ba113